### PR TITLE
Use helper for module titles in sort

### DIFF
--- a/src/apps/FindTheCulprit.mjs
+++ b/src/apps/FindTheCulprit.mjs
@@ -1,6 +1,6 @@
 import { MODULE, MODULE_ID, MMSetting } from "../constants.mjs";
 import { FindTheCulpritModuleData } from "../data/models.mjs";
-import { debug, oxfordList, shuffleArray } from "../helpers.mjs";
+import { debug, oxfordList, shuffleArray, getModuleTitle } from "../helpers.mjs";
 const { ApplicationV2, HandlebarsApplicationMixin, DialogV2 } = foundry.applications.api;
 const standardWidth = 425;
 
@@ -864,9 +864,14 @@ export class FindTheCulprit extends HandlebarsApplicationMixin(ApplicationV2) {
       ),
     };
     for (const group in templateContext.groups) {
-      templateContext.groups[group].sort((a, b) =>
-        game.modules.get(a.id).title.localeCompare(game.modules.get(b.id).title)
-      );
+      templateContext.groups[group].sort((a, b) => {
+        const titleA = getModuleTitle(a.id);
+        const titleB = getModuleTitle(b.id);
+        if (typeof titleA === "string" && typeof titleB === "string") {
+          return titleA.localeCompare(titleB);
+        }
+        return a.id.localeCompare(b.id);
+      });
     }
     const titleKey = `FindTheCulprit.BinarySearchStep.${isConfirmStep ? "ConfirmStep" : ""}Title`;
     const dialogOptions = this.#defaultDialogOptions({

--- a/src/helpers.mjs
+++ b/src/helpers.mjs
@@ -11,6 +11,10 @@ export function shuffleArray(array) {
   }
 }
 
+export function getModuleTitle(id) {
+  return game.modules.get(id)?.title;
+}
+
 export function oxfordList(list, { and = "and" } = {}) {
   if (list instanceof Set) list = Array.from(list);
   list = (Array.isArray(list) ? list : [list]).filter((e) => !!e).map((e) => String(e));


### PR DESCRIPTION
## Summary
- add getModuleTitle helper
- use helper to sort modules by title when available

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_689da51a2574832eb46e347734dd8def