### PR TITLE
fix: stabilize GM sorting

### DIFF
--- a/src/helpers.mjs
+++ b/src/helpers.mjs
@@ -24,6 +24,6 @@ export function oxfordList(list, { and = "and" } = {}) {
 
 export function activeRealGM() {
   const activeRealGMs = game.users.filter((u) => u.active && u.role === CONST.USER_ROLES.GAMEMASTER);
-  activeRealGMs.sort((a, b) => (a.id > b.id ? 1 : -1));
+  activeRealGMs.sort((a, b) => a.id.localeCompare(b.id));
   return activeRealGMs[0] || null;
 }


### PR DESCRIPTION
## Summary
- ensure active GM detection sorts IDs deterministically

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_689da254f148832e9aacb78684dfe52f